### PR TITLE
Resolve link-stage error regarding OpenCV.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ ament_target_dependencies(ipcamera_component
   "rclcpp"
   "rclcpp_components"
   "cv_bridge"
+  "OpenCV"
   "sensor_msgs"
   "camera_info_manager"
   "camera_calibration_parsers"


### PR DESCRIPTION
Had linking problems when building for humble, fixed with only a minor dependency addition.
```
--- stderr: ros2_ipcamera                                                                      
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::VideoCapture()'
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::isOpened() const'
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::~VideoCapture()'
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::operator>>(cv::Mat&)'
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/bin/ld: libipcamera_component.so: undefined reference to `cv::VideoCapture::set(int, double)'
collect2: error: ld returned 1 exit status

```